### PR TITLE
Made a copy of state to avoid mutating it

### DIFF
--- a/lib/meteoredux.js
+++ b/lib/meteoredux.js
@@ -74,7 +74,7 @@ function MeteorRedux(store) {
 
 function updateData(state, data) {
 
-  var result = state; //deep clone?
+  var result = Object.assign({}, state);
 
   if (!(data && typeof data === 'object')) {
     throw new Error("Expected object returned from bindReactiveData");

--- a/src/meteoredux.js
+++ b/src/meteoredux.js
@@ -72,7 +72,7 @@ function MeteorRedux(store){
 
 function updateData(state, data) {
 
-  let result = state; //deep clone?
+  let result = Object.assign({}, state);
 
   if (! (data && (typeof data) === 'object')) {
     throw new Error("Expected object returned from bindReactiveData");


### PR DESCRIPTION
- redux reducers cannot mutate the state
- redux functions, like mapStateToProps, won't be flagged for recompute if state is mutated
- this is determined via the root reducers' hasChanged var
- in response to issue #2 
- this package is now working nicely with our redux project on Meteor 1.3.4.1, after this change
